### PR TITLE
ci: Remove check for whether GitHub Pages is enabled

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,32 +18,8 @@ permissions:
   id-token: write
 
 jobs:
-  check:
-    name: Check if GitHub Pages is enabled
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh api "repos/${{ github.repository }}/pages" | jq --exit-status '.build_type == "workflow"'
-          then
-              echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-              echo "# Not published to GitHub Pages" >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo -n "Check that Pages is enabled, with the source set to GitHub Actions, in the " >> "$GITHUB_STEP_SUMMARY"
-              echo "[repository settings](https://github.com/${{ github.repository }}/settings/pages)." >> "$GITHUB_STEP_SUMMARY"
-          fi
-    outputs:
-      enabled: ${{ steps.check.outputs.enabled }}
-
   publish:
     name: Publish all branches to GitHub Pages
-    needs:
-      - check
-    if: ${{ needs.check.outputs.enabled }}
     runs-on: ubuntu-latest
     steps:
       - uses: endlessm/amalgamate-pages@v1


### PR DESCRIPTION
I put this check into the ancestor of this workflow partly to provide a hint when someone inexperienced with GitHub Actions & Pages tries to reuse the workflow, but mainly to avoid wasting resources building the web version of the game if it's not going to be used.

However, the web version of the game is now built unconditionally in the 'export.yml' workflow. And in practice this check always succeeds; if it fails, the developer setting up the workflow will figure it out. So it is currently just adding ~10 seconds of extra time to the build process for no benefit.

Remove it.