### PR TITLE
Implement deep-linking to worlds on the web

### DIFF
--- a/Script/SceneSwitcher.gd
+++ b/Script/SceneSwitcher.gd
@@ -1,0 +1,55 @@
+extends Node
+
+const MAIN_MENU_SCENE := preload("res://Scene/WorldSelector.tscn") as PackedScene
+var _world_rx := RegEx.create_from_string("^res://(?<world>.+)/World.tscn$")
+
+## Proxy object for the 'window' DOM object, or null if not running on the web
+var _window: JavaScriptObject
+
+
+func _ready() -> void:
+	if OS.has_feature("web"):
+		_window = JavaScriptBridge.get_interface("window")
+		_restore_from_hash.call_deferred()
+
+
+## On the web, load the world indicated by the URL hash, if any.
+func _restore_from_hash():
+	var hash := _window.location.hash as String
+	if hash:
+		var world := hash.right(-1).uri_decode()
+		var scene := "res://".path_join(world).path_join("World.tscn")
+		if ResourceLoader.exists(scene):
+			change_to_file(scene)
+		else:
+			print("No world found matching ", hash, "; ignoring")
+
+
+## On the web, update or clear the URL hash to indicate the current world.
+func _set_hash(hash: String):
+	if _window:
+		var url = JavaScriptBridge.create_object("URL", _window.location.href)
+		url.hash = "#" + hash
+		# Replace the current URL rather than simply updating window.location to
+		# avoid creating misleading history entries that don't work if you press
+		# the browser's back button.
+		_window.location.replace(url.href)
+
+
+## Switch to the given scene
+func change_to_file(path: String):
+	var rx_match := _world_rx.search(path)
+	if rx_match:
+		_set_hash(rx_match.get_string("world"))
+
+	var err := get_tree().change_scene_to_file(path)
+	if err != OK:
+		push_error("Failed to open ", path, ": ", error_string(err))
+
+
+## Switch to the main menu scene
+func change_to_menu() -> void:
+	_set_hash("")
+	var err := get_tree().change_scene_to_packed(MAIN_MENU_SCENE)
+	if err != OK:
+		push_error("Failed to open main menu: ", error_string(err))

--- a/Script/SceneSwitcher.gd.uid
+++ b/Script/SceneSwitcher.gd.uid
@@ -1,0 +1,1 @@
+uid://frdyw6f4ewox

--- a/Script/World.gd
+++ b/Script/World.gd
@@ -58,7 +58,7 @@ func _instantiate_level():
 
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
-		get_tree().change_scene_to_file("res://Scene/WorldSelector.tscn")
+		SceneSwitcher.change_to_menu()
 
 func _process(_delta: float):
 	if Input.is_action_just_pressed("jump") and _level_scene.level_type != Level.LevelType.NORMAL:

--- a/Script/WorldSelector.gd
+++ b/Script/WorldSelector.gd
@@ -5,7 +5,7 @@ extends Control
 @onready var SettingsPage = $SettingsPage
 
 func _enter_world(world: String) -> void:
-	get_tree().change_scene_to_file(world)
+	SceneSwitcher.change_to_file(world)
 
 
 func _on_main_world_selected() -> void:

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ config/icon="res://icon.svg"
 
 global="*res://Script/Global.gd"
 Settings="*res://Script/Settings.gd"
+SceneSwitcher="*res://Script/SceneSwitcher.gd"
 
 [display]
 


### PR DESCRIPTION
Add a global SceneSwitcher node, which replaces direct calls to
SceneTree.change_scene_to_file() in the menu and world code, so that
there is one central location to react to switching between worlds.

Then, when switching to a world, place the path to its directory into
the URL hash. When switching to the main menu, clear the hash. When the
game loads, check if the URL hash contains a valid world path and switch
to it if so.

This allows deep-linking to specific worlds of the game, which learners
may well want to do to share their world with their friends.

One caveat is that in some browsers sound does not work until you first
click on the game or press a key, due to security restrictions. This is
not noticeable in the normal case where the player starts on the main
menu, since the main menu has no sound, and getting to a world requires
clicking or pressing a key. But when launching straight into a world,
the music will not play immediately. The problem will resolve itself as
soon as the user presses Jump to actually start playing.

Fixes #138

